### PR TITLE
Fix event loop blocking in thinking loop

### DIFF
--- a/hermitclaw/brain.py
+++ b/hermitclaw/brain.py
@@ -565,7 +565,7 @@ class Brain:
         instructions, input_list = self._build_input()
 
         try:
-            response = chat(input_list, tools=True, instructions=instructions)
+            response = await asyncio.to_thread(chat, input_list, True, instructions)
         except Exception as e:
             logger.error(f"LLM call failed: {e}")
             await self._emit("error", text=str(e))
@@ -602,7 +602,7 @@ class Brain:
                     elif tool_name == "respond":
                         result = await self._handle_respond(tool_args)
                     else:
-                        result = execute_tool(tool_name, tool_args, self.env_path)
+                        result = await asyncio.to_thread(execute_tool, tool_name, tool_args, self.env_path)
                 except Exception as e:
                     result = f"Error: {e}"
 
@@ -620,7 +620,7 @@ class Brain:
                 })
 
             try:
-                response = chat(input_list, tools=True, instructions=instructions)
+                response = await asyncio.to_thread(chat, input_list, True, instructions)
             except Exception as e:
                 logger.error(f"LLM follow-up call failed: {e}")
                 await self._emit("error", text=str(e))


### PR DESCRIPTION
## Summary

- `_think_once()` calls `chat()` and `execute_tool()` synchronously, which blocks the asyncio event loop for the entire duration of each LLM API call and shell command execution
- While blocked, the server cannot handle any HTTP requests or WebSocket messages, making the web UI completely unresponsive ("site not reachable")
- `_reflect()` and `_plan()` already use `asyncio.to_thread()` correctly — this PR applies the same pattern to the 3 blocking calls in `_think_once()`

## Root Cause

The `chat()` function uses the synchronous `openai.OpenAI` client. When called from the async `_think_once()` method without `asyncio.to_thread()`, it blocks the event loop. With fast API responses (e.g. OpenAI), the blocking window may be short enough that the page loads during `asyncio.sleep()` gaps between thoughts. With slower providers, the server becomes permanently unresponsive.

## Test plan

- [ ] Start the server with `python hermitclaw/main.py`
- [ ] Open `http://localhost:8000` — page should load immediately, even while the crab is thinking
- [ ] Verify the crab still thinks, uses tools, and reflects normally
- [ ] Verify WebSocket updates stream to the frontend in real-time during thinking

🤖 Generated with [Claude Code](https://claude.com/claude-code)